### PR TITLE
Fix userid weirdness

### DIFF
--- a/src/routes/(app)/picture/new/+page.svelte
+++ b/src/routes/(app)/picture/new/+page.svelte
@@ -5,8 +5,11 @@
 	import { fb_storage } from '$lib/firebase';
 	import { getDownloadURL, ref, uploadBytes } from 'firebase/storage';
 	import { userInfo } from '$lib/stores/user.store';
+	import type { PageData } from './$types';
 
-	let userId = $userInfo.userId;
+	export let data: PageData;
+
+	let userId = data.userId;
 
 	let description: string;
 	let title: string;

--- a/src/routes/(app)/profile/edit/+page.svelte
+++ b/src/routes/(app)/profile/edit/+page.svelte
@@ -9,7 +9,8 @@
 
 	export let data: PageData;
 
-	let userID: string = $userInfo.userId;
+	//@ts-ignore
+	let userID: string = data.userId;
 	//@ts-ignore
 	let name: string = data.user.displayName;
 	//@ts-ignore

--- a/src/routes/(app)/recipe/new/+page.svelte
+++ b/src/routes/(app)/recipe/new/+page.svelte
@@ -10,7 +10,7 @@
 
 	export let data: PageData;
 
-	let userId = $userInfo.userId;
+	let userId = data.userId;
 
 	let recipeName: string;
 	let description: string;


### PR DESCRIPTION
The userInfo store does not always populate with the userId. This causes an issue where a recipe will get inserted without a user id sometimes.

Changed the variable that gets inserted to using the Sveltekit data value rather then the store.