### PR TITLE
Fixed profile page not loading posts

### DIFF
--- a/src/routes/(app)/profile/[user_id]/+page.svelte
+++ b/src/routes/(app)/profile/[user_id]/+page.svelte
@@ -21,7 +21,7 @@
 	let tempPosts: any;
 	let tempItems;
 
-	let userID = $userInfo.userId;
+	let userID = data.user.userId;
 
 	const getMorePosts = async (pageNum: Number) => {
 		try {


### PR DESCRIPTION
fixed the bug when users posts on a different users profile page would not load if you were logged out.